### PR TITLE
Add molecule

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,33 @@
+---
+# Based on ansible-lint config
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
+  truthy: disable

--- a/molecule/default/INSTALL.rst
+++ b/molecule/default/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ pip install 'molecule[docker]'

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,0 +1,16 @@
+---
+- name: 'Converge'
+  hosts: 'all'
+  vars:
+    vsftpd_enable_virt_users: true
+    vsftpd_chroot_local_users: true
+    vsftpd_virt_users:
+      - username: 'user'
+        guest_username: 'user'
+        password: 'password'
+        local_root: '/tmp'
+        write_enable: false
+  tasks:
+    - name: 'Run role'
+      ansible.builtin.import_role:
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,17 @@
+---
+dependency:
+  name: 'galaxy'
+driver:
+  name: ${DRIVER_NAME:-docker}
+platforms:
+  - name: "vsftpd"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian10}-ansible:latest"
+    command: '/lib/systemd/systemd'
+    pre_build_image: true
+    volumes:
+      - '/sys/fs/cgroup:/sys/fs/cgroup:ro'
+    privileged: true
+provisioner:
+  name: 'ansible'
+verifier:
+  name: 'ansible'

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,0 +1,13 @@
+---
+- name: 'Update package sources'
+  hosts: 'all'
+  tasks:
+    - name: 'Update APT cache'
+      ansible.builtin.apt:
+        update_cache: true
+      when: ansible_facts['os_family'] == 'Debian'
+
+    - name: 'Update YUM cache'
+      ansible.builtin.yum:
+        update_cache: true
+      when: ansible_facts['os_family'] == 'RedHat'

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,8 @@
+---
+# This is an example playbook to execute Ansible tests.
+- name: Verify
+  hosts: all
+  tasks:
+    - name: Example assertion
+      ansible.builtin.assert:
+        that: true


### PR DESCRIPTION
I've added some basic Molecule tests to validate role functionality, it works with either Podman or Docker in this setup.

By  default it tests with debian10, but if you set an envvar named ```MOLECULE_DISTRO``` you can change the image used to any provided by geerlingguy. Like so:

```
MOLECULE_DISTRO=centos8 molecule converge
MOLECULE_DISTRO=centos8 molecule idempotence
```

And Molecule will work it's magic and help test it :)