### PR TITLE
make role ansible 2.16 compatible

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,10 +1,10 @@
 ---
 - name: "restarting specific {{ vsftpd_systemd_service_name }} service"
-  service:
+  ansible.builtin.service:
     name: "vsftpd@{{ vsftpd_systemd_service_name }}"
     state: restarted
 
 - name: restarting vsftpd service
-  service:
+  ansible.builtin.service:
     name: vsftpd
     state: restarted

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -1,7 +1,6 @@
 ---
-
 - name: installing vsftpd package
-  apt:
+  ansible.builtin.apt:
     name: "{{ item }}"
     state: present
     update_cache: true
@@ -10,28 +9,28 @@
 
 - name: "copying vsftpd systemd service file for \
 {{ vsftpd_systemd_service_name }} instance"
-  template:
+  ansible.builtin.template:
     src: vsftpd.service.j2
     dest: /etc/systemd/system/vsftpd@{{ vsftpd_systemd_service_name }}.service
     mode: '664'
   when: vsftpd_systemd_service_name != 'vsftpd'
 
 - name: "configuring systemd for {{ vsftpd_systemd_service_name }} instance"
-  systemd:
+  ansible.builtin.systemd:
     name: "vsftpd@{{ vsftpd_systemd_service_name }}"
     daemon_reload: true
     enabled: true
   when: vsftpd_systemd_service_name != 'vsftpd'
 
 - name: configuring systemd for vsftpd
-  systemd:
+  ansible.builtin.systemd:
     name: vsftpd
     daemon_reload: true
     enabled: true
   when: vsftpd_systemd_service_name == 'vsftpd'
 
 - name: configuring vsftpd instance
-  template:
+  ansible.builtin.template:
     src: vsftpd.conf.j2
     dest: /etc/vsftpd.conf
     owner: root
@@ -42,7 +41,7 @@
   when: vsftpd_systemd_service_name == 'vsftpd'
 
 - name: "configuring {{ vsftpd_systemd_service_name }} instance"
-  template:
+  ansible.builtin.template:
     src: vsftpd.conf.j2
     dest: /etc/{{ vsftpd_systemd_service_name }}.conf
     owner: root

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -1,7 +1,6 @@
 ---
-
 - name: installing vsftpd package
-  yum:
+  ansible.builtin.yum:
     name: "{{ item }}"
     state: present
     update_cache: true
@@ -9,31 +8,29 @@
     - vsftpd
     - libdb-utils
 
-- name: "copying vsftpd systemd service file \
-for {{ vsftpd_systemd_service_name }}"
-  template:
+- name: "copying vsftpd systemd service file for {{ vsftpd_systemd_service_name }}"
+  ansible.builtin.template:
     src: vsftpd.service.j2
     dest: /etc/systemd/system/vsftpd@{{ vsftpd_systemd_service_name }}.service
     mode: '664'
   when: vsftpd_systemd_service_name != 'vsftpd'
 
-- name: "configuring systemd \
-for {{ vsftpd_systemd_service_name }}"
-  systemd:
+- name: "configuring systemd for {{ vsftpd_systemd_service_name }}"
+  ansible.builtin.systemd:
     name: "vsftpd@{{ vsftpd_systemd_service_name }}"
     daemon_reload: true
     enabled: true
   when: vsftpd_systemd_service_name != 'vsftpd'
 
 - name: configuring systemd for vsftpd
-  systemd:
+  ansible.builtin.systemd:
     name: vsftpd
     daemon_reload: true
     enabled: true
   when: vsftpd_systemd_service_name == 'vsftpd'
 
 - name: configuring vsftpd instance
-  template:
+  ansible.builtin.template:
     src: vsftpd.conf.j2
     dest: /etc/vsftpd/vsftpd.conf
     owner: root
@@ -44,14 +41,14 @@ for {{ vsftpd_systemd_service_name }}"
   when: vsftpd_systemd_service_name == 'vsftpd'
 
 - name: "creating {{ vsftpd_systemd_service_name }} configuration directory"
-  file:
+  ansible.builtin.file:
     state: directory
     path: "/etc/vsftpd/{{ vsftpd_systemd_service_name }}/"
     mode: '775'
   when: vsftpd_systemd_service_name != 'vsftpd'
 
 - name: "configuring {{ vsftpd_systemd_service_name }} instance"
-  template:
+  ansible.builtin.template:
     src: vsftpd.conf.j2
     dest: /etc/vsftpd/{{ vsftpd_systemd_service_name }}/vsftpd.conf
     owner: root

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 
-- include: install-redhat.yml
+- ansible.builtin.include_tasks: install-redhat.yml
   when: ansible_os_family == 'RedHat'
 
-- include: install-debian.yml
+- ansible.builtin.include_tasks: install-debian.yml
   when: ansible_os_family == 'Debian'
 
-- include: virtual-users.yml
+- ansible.builtin.include_tasks: virtual-users.yml
   when: vsftpd_enable_virt_users

--- a/tasks/virtual-users.yml
+++ b/tasks/virtual-users.yml
@@ -1,20 +1,20 @@
 ---
 - name: creating default users config directory
-  file:
+  ansible.builtin.file:
     state: directory
     path: /etc/vsftpd/users.d/
     mode: '775'
   when: vsftpd_systemd_service_name == 'vsftpd'
 
 - name: "creating {{ vsftpd_systemd_service_name }} users config directory"
-  file:
+  ansible.builtin.file:
     state: directory
     path: "/etc/vsftpd/{{ vsftpd_systemd_service_name }}/users.d/"
     mode: '775'
   when: vsftpd_systemd_service_name != 'vsftpd'
 
 - name: creating default users config
-  template:
+  ansible.builtin.template:
     src: users_config.j2
     dest: "/etc/vsftpd/users.d/{{ item['username'] }}"
     mode: '644'
@@ -27,7 +27,7 @@
   no_log: "{{ vsftpd_no_log }}"
 
 - name: "creating {{ vsftpd_systemd_service_name }} users config"
-  template:
+  ansible.builtin.template:
     src: users_config.j2
     dest: "/etc/vsftpd/{{ vsftpd_systemd_service_name }}/ \
       users.d/{{ item['username'] }}"
@@ -68,7 +68,7 @@
 
 - name: "configuring pam for {{ vsftpd_systemd_service_name }} \
 vsftpd virtual users"
-  template:
+  ansible.builtin.template:
     src: vsftpd_pam.j2
     dest: "/etc/pam.d/{{ vsftpd_systemd_service_name }}"
     owner: root
@@ -77,7 +77,7 @@ vsftpd virtual users"
   when: vsftpd_systemd_service_name != 'vsftpd'
 
 - name: adding virtual users to default database
-  template:
+  ansible.builtin.template:
     src: users_db.j2
     dest: /etc/vsftpd/login.txt
     owner: root
@@ -87,7 +87,7 @@ vsftpd virtual users"
   register: vsftpd_db_default
 
 - name: "adding virtual users to {{ vsftpd_systemd_service_name }}"
-  template:
+  ansible.builtin.template:
     src: users_db.j2
     dest: "/etc/vsftpd/{{ vsftpd_systemd_service_name }}/login.txt"
     owner: root
@@ -97,14 +97,14 @@ vsftpd virtual users"
   register: vsftpd_db_custom
 
 - name: generating default virtual users database
-  command: db_load -T -t hash -f /etc/vsftpd/login.txt /etc/vsftpd/login.db
+  ansible.builtin.command: db_load -T -t hash -f /etc/vsftpd/login.txt /etc/vsftpd/login.db
   when:
     - vsftpd_systemd_service_name == 'vsftpd'
     - vsftpd_db_default['changed']
   notify: restarting vsftpd service
 
 - name: "generating {{ vsftpd_systemd_service_name }} virtual users database"
-  command: "db_load -T -t hash \
+  ansible.builtin.command: "db_load -T -t hash \
   -f /etc/vsftpd/{{ vsftpd_systemd_service_name }}/login.txt \
   /etc/vsftpd/{{ vsftpd_systemd_service_name }}/login.db"
   when:
@@ -113,7 +113,7 @@ vsftpd virtual users"
   notify: "restarting specific {{ vsftpd_systemd_service_name }} service"
 
 - name: changing mode for default virtual users database
-  file:
+  ansible.builtin.file:
     state: file
     path: /etc/vsftpd/login.db
     owner: root
@@ -123,7 +123,7 @@ vsftpd virtual users"
 
 - name: "changing mode for \
 {{ vsftpd_systemd_service_name }} virtual users database"
-  file:
+  ansible.builtin.file:
     state: file
     path: "/etc/vsftpd/{{ vsftpd_systemd_service_name }}/login.db"
     owner: root


### PR DESCRIPTION
## Changes
- replace`include` with `inclulde_tasks` because of deprecation in ansible
versions which are released after 2023-05-16

```
ERROR! [DEPRECATED]: ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.
```

- add fully-qualified collection names as recommended in the ansible 2.10
porting guide: https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.10.html

### Remark
I was not able to test the redhat version, but I think it should work.